### PR TITLE
Fixes missing ansible user

### DIFF
--- a/roles/metadata/meta/main.yml
+++ b/roles/metadata/meta/main.yml
@@ -50,4 +50,5 @@ galaxy_info:
     #       Maximum 20 tags per role.
 
 dependencies:
+  - role: bitsyai.printnanny.common
   - role: bitsyai.printnanny.install


### PR DESCRIPTION
TASK [bitsyai.printnanny.metadata : Create /opt/printnanny/ansible/collections] **************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "gid": 1001, "group": "printnanny", "mode": "0755", "msg": "chown failed: failed to look up user ansible", "owner": "printnanny", "path": "/opt/printnanny/ansible/collections", "size": 4096, "state": "directory", "uid": 1001}