### PR TITLE
Fix ownership of nn model dir

### DIFF
--- a/roles/install/tasks/camera.yml
+++ b/roles/install/tasks/camera.yml
@@ -6,6 +6,8 @@
     state: directory
     path: '{{ nn_install_dir }}'
     mode: 0775
+    owner: '{{ printnanny_user }}'
+    group: '{{ printnanny_user }}'
 
 - name: Download {{ nn_model_url }}
   become: true


### PR DESCRIPTION
Fix ownership of nn model dir, currently owned by `root`
```
pi@octonanny-dev:~ $ ls -ahl /opt/printnanny/
total 24K
drwxr-xr-x 6 printnanny printnanny 4.0K Feb 26 10:48 .
drwxr-xr-x 4 root       root       4.0K Feb 26 10:40 ..
drwxrwxr-x 5 printnanny printnanny 4.0K Feb 26 11:29 ansible
drwxrwxr-x 2 root       root       4.0K Feb 26 10:44 nn
drwxr-xr-x 4 printnanny printnanny 4.0K Feb 26 11:50 profiles
drwxrwxr-x 3 printnanny printnanny 4.0K Feb 26 11:33 www
````