### PR TITLE
add RuntimeDirectory= and ConfigurationDirectory= directives to printnanny-events.service

### DIFF
--- a/roles/install/templates/systemd/mqtt.service.j2
+++ b/roles/install/templates/systemd/mqtt.service.j2
@@ -8,6 +8,9 @@ PartOf=printnanny.target
 [Service]
 Type=simple
 SyslogIdentifier=printnanny-events
+RuntimeDirectory={{ printnanny_user }}
+RuntimeDirectoryPreserve=yes
+ConfigurationDirectory={{ printnanny_user }}
 EnvironmentFile=-{{ printnanny_env }}
 ExecStart=/usr/local/bin/printnanny -v event subscribe
 User={{ printnanny_user }}


### PR DESCRIPTION
Resolves the following error seen after locking down user permissions
```
Feb 26 16:30:01 octonanny-dev printnanny-events[55058]: Error: Failed to bind to socket /var/run/printnanny/events.sock
Feb 26 16:30:01 octonanny-dev printnanny-events[55058]: Caused by:
Feb 26 16:30:01 octonanny-dev printnanny-events[55058]:     Permission denied (os error 13)
```