### PR TITLE
Do not create/push tag when bumping version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 1.4.3
 commit = True
-tag = True
+tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>(dev|rc))+(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}


### PR DESCRIPTION
Instead, create a tag when release is published