### PR TITLE
Ensure facts.json directory exists + owner is update_user

### DIFF
--- a/roles/metadata/tasks/update/main.yml
+++ b/roles/metadata/tasks/update/main.yml
@@ -8,10 +8,22 @@
     - setup
     - metadata
 
-- name: Create {{ printnanny_ansible_dir }}/collections
+- name: Create {{ printnanny_ansible_dir }}
   become: true
   ansible.builtin.file:
-    path: '{{ printnanny_ansible_dir }}/collections'
+    path: '{{ printnanny_ansible_dir }}'
+    state: directory
+    mode: 0755
+    owner: '{{ update_user }}'
+    group: '{{ update_user }}'
+  tags:
+    - setup
+    - metadata
+
+- name: Create {{ printnanny_ansible_dir }}/facts.json/
+  become: true
+  ansible.builtin.file:
+    path: '{{ printnanny_ansible_dir }}/facts.json/'
     state: directory
     mode: 0755
     owner: '{{ update_user }}'


### PR DESCRIPTION
Should fix the following warning:
```
Feb 26 21:14:21 octonanny-dev printnanny-events[89256]:      stderr=[WARNING]: error in 'jsonfile' cache, configured path
Feb 26 21:14:21 octonanny-dev printnanny-events[89256]:     (/opt/printnanny/ansible/facts.json) does not have necessary permissions (rwx),
Feb 26 21:14:21 octonanny-dev printnanny-events[89256]:     disabling plugin
```