### PR TITLE
Fix collection url

### DIFF
--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -46,7 +46,7 @@ printnanny_config_toml: '{{ printnanny_profile_dir }}/PrintNanny.toml'
 printnanny_backups_dir: "{{ printnanny_profile_dir }}/backups"
 printnanny_ansible_dir: "{{ printnanny_install_dir }}/ansible"
 updater_venv: '{{ printnanny_ansible_dir }}/venv'
-updater_collection_url: 'git+https://github.com/bitsy-ai/ansible-collection-printnanny.git,{{ printnanny_release_channel }}'
+updater_collection_url: 'git+https://github.com/bitsy-ai/ansible-collection-printnanny.git'
 
 printnanny_www_dir: '{{ printnanny_install_dir }}/www'
 printnanny_www_secret_file: '{{ printnanny_www_dir }}/key'


### PR DESCRIPTION
Fixes release channel being rendered twice:

```
ExecStart=/usr/bin/flock --verbose -n /var/run/printnanny/ansible.lock \
    /opt/printnanny/ansible/venv/bin/ansible-galaxy \
    collection install --upgrade git+https://github.com/bitsy-ai/ansible-collection-printnanny.git,main,${PRINTNANNY_RELEASE_CHANNEL} \
```