### PR TITLE
Render printnanny_data_dir to firstboot.toml

### DIFF
--- a/roles/install/templates/config.toml.j2
+++ b/roles/install/templates/config.toml.j2
@@ -1,6 +1,7 @@
 profile = "{{ printnanny_profile }}"
 firstboot_file = "{{ printnanny_firstboot_toml }}"
 install_dir = "{{ printnanny_profile_dir }}"
+data_dir = "{{ printnanny_data_dir }}"
 runtime_dir = "{{ printnanny_runtime_dir }}"
 events_socket = "{{ printnanny_runtime_dir }}/events.sock"
 edition = "{{ printnanny_edition }}"


### PR DESCRIPTION
Fixes panic in latest nightly:
```
Apr 13 20:42:29 octonanny-dev-04-13 printnanny-www[11054]: thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: Error { tag: Tag::Default, profile: None, metadata: None, path: [], kind: MissingField("data_dir"), prev: None }', services/src/config.rs:286:14
```