### PR TITLE
add a restart to nginx service on failure

### DIFF
--- a/roles/install/files/nginx.service
+++ b/roles/install/files/nginx.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=nginx - high performance web server
+Documentation=http://nginx.org/en/docs/
+After=network.target network-online.target remote-fs.target nss-lookup.target
+Wants=network.target network-online.target nss-lookup.target
+StartLimitIntervalSec=500
+StartLimitBurst=5
+
+[Service]
+Type=forking
+PIDFile=/var/run/nginx.pid
+ExecStart=/usr/sbin/nginx -c /etc/nginx/nginx.conf
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/install/tasks/nginx.yml
+++ b/roles/install/tasks/nginx.yml
@@ -1,3 +1,10 @@
+- name: Copy nginx.service to target
+  become: true
+  ansible.builtin.copy:
+    src: nginx.service
+    dest: /etc/systemd/system/nginx.service
+    mode: 0664
+
 - name: Install NGINX
   include_role:
     name: nginxinc.nginx_core.nginx
@@ -9,6 +16,7 @@
     nginx_logrotate_conf_enable: false
     nginx_modules:
       - njs
+    nginx_service_custom_file: /etc/systemd/system/nginx.service
 
 - name: Ensure log dir exists
   become: true


### PR DESCRIPTION
if DNS fails to resolve, nginx service will fail. retrying with a max burst of 5 attempts should fix this issue without worrying about nginx going into a loop if a bad config is applied. 

```
pi@nightly-04-21:~ $ sudo systemctl status nginx
● nginx.service - nginx - high performance web server
     Loaded: loaded (/lib/systemd/system/nginx.service; enabled; vendor preset: enabled)
     Active: failed (Result: exit-code) since Sun 2022-03-20 12:55:54 PDT; 1 months 1 days ago
       Docs: https://nginx.org/en/docs/
        CPU: 30ms

Mar 20 12:55:50 nightly-04-21 systemd[1]: Starting nginx - high performance web server...
Mar 20 12:55:54 nightly-04-21 nginx[589]: nginx: [emerg] host not found in upstream "live.printnanny.ai" in /etc/nginx/conf.d/printnanny.locations:21
Mar 20 12:55:54 nightly-04-21 systemd[1]: nginx.service: Control process exited, code=exited, status=1/FAILURE
Mar 20 12:55:54 nightly-04-21 systemd[1]: nginx.service: Failed with result 'exit-code'.
Mar 20 12:55:54 nightly-04-21 systemd[1]: Failed to start nginx - high performance web server.
```