### PR TITLE
hotfix: include octoprint facts tasks always

### DIFF
--- a/roles/install/tasks/firstboot/certs.yml
+++ b/roles/install/tasks/firstboot/certs.yml
@@ -98,7 +98,6 @@
     apply:
       tags:
         - firstboot
-  when: octoprint_python_version is not defined
   tags:
     - firstboot
 


### PR DESCRIPTION
system playbook is failing on update runs with error:

```
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: TASK [bitsyai.printnanny.install : Render config.toml] *************************
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: task path: /opt/printnanny/ansible/ansible_collections/bitsyai/printnanny/roles/install/tasks/firstboot/certs.yml:105
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'octoprint_dir' is undefined
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: fatal: [localhost]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'octoprint_dir' is undefined"}
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: RUNNING HANDLER [bitsyai.printnanny.handlers : restart printnanny-dash] ********
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: task path: /opt/printnanny/ansible/ansible_collections/bitsyai/printnanny/roles/handlers/handlers/main.yml:27
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: [WARNING]: Failure using method (v2_playbook_on_handler_task_start) in callback
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: plugin (<ansible.plugins.callback.ara_default.CallbackModule object at
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: 0x7fa7660460>): 'NoneType' object is not subscriptable
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: PLAY RECAP *********************************************************************
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: localhost                  : ok=141  changed=13   unreachable=0    failed=1    skipped=36   rescued=0    ignored=0
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: [WARNING]: Failure using method (v2_playbook_on_stats) in callback plugin
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: (<ansible.plugins.callback.ara_default.CallbackModule object at 0x7fa7660460>):
Apr 21 11:09:09 nightly-04-21 printnanny-update[10031]: 'NoneType' object is not subscriptable
Apr 21 11:09:09 nightly-04-21 printnanny-update[10029]: flock: getting lock took 0.000011 seconds
Apr 21 11:09:09 nightly-04-21 printnanny-update[10029]: flock: executing /opt/printnanny/ansible/venv/bin/ansible-playbook
```